### PR TITLE
Some minor fixes

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -49,7 +49,9 @@ func (u *ui) askShutdown() {
 	message.Alignment = fyne.TextAlignCenter
 
 	buttons := container.NewGridWithColumns(3,
-		widget.NewButtonWithIcon("Cancel", theme.CancelIcon(), pop.Hide),
+		widget.NewButtonWithIcon("Cancel", theme.CancelIcon(), func() {
+			pop.Hide()
+		}),
 		widget.NewButtonWithIcon("Reboot", theme.ViewRefreshIcon(), func() {
 			pop.Hide()
 			_ = exec.Command("shutdown", "-r", "now").Start()
@@ -159,7 +161,7 @@ func (u *ui) loadUI() {
 
 	u.win.SetContent(container.NewMax(bg,
 		container.NewCenter(container.NewMax(box, container.NewVBox(
-			widget.NewLabelWithStyle(fmt.Sprintf("Log in to %s", u.hostname()), fyne.TextAlignCenter, fyne.TextStyle{Bold: true}),
+			widget.NewLabelWithStyle("Log in to "+u.hostname(), fyne.TextAlignCenter, fyne.TextStyle{Bold: true}),
 			widget.NewSeparator(),
 
 			container.NewMax(widget.NewLabel(""), u.err),

--- a/ui.go
+++ b/ui.go
@@ -172,7 +172,7 @@ func (u *ui) loadUI() {
 
 	matched := false
 	storedName := u.pref.String(prefUserKey)
-	for i, name := range u.users() {
+	for i, name := range users {
 		if name != storedName {
 			continue
 		}

--- a/ui.go
+++ b/ui.go
@@ -190,11 +190,11 @@ func (u *ui) loadUI() {
 }
 
 func (u *ui) sessionNames() []string {
-	var ret []string
-	for _, sess := range u.sessions {
-		ret = append(ret, sess.name)
+	names := make([]string, len(u.sessions))
+	for i, sess := range u.sessions {
+		names[i] = sess.name
 	}
-	return ret
+	return names
 }
 
 func (u *ui) sessionExec() string {


### PR DESCRIPTION
This does four things that basically were too small to split up into separate PRs.

1. I noticed that the suggestion that I made about removing a function actually makes it crash because the pointer for the popup does not exist when the button is created.
2. The users were loaded twice instead of once. Should make the startup time a bit faster.
3. The session names are now pre-allocated to shave off some time and memory usage.
4. Removed an unnecessary call to `fmt.Sprintf`.