### PR TITLE
Initial OpenBSD build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal but good-looking login manager for Linux/Unix.
 The current boot scripts support only systemd.
 
 If you'd like to try out this project in its early stages
-then you can simply check out this repo and run:
+then you can simply check out this repo and run (Linux with systemd assumed):
 
 ```shell
 $ make
@@ -21,7 +21,18 @@ $ systemctl start fin
 
 That should be all you need if you are transitioning away from
 another Display Manager. If you run into issues using Fin,
-please visit [Troubleshooting](# Troubleshooting) below.
+please visit [Troubleshooting](#troubleshooting) below.
+
+### OpenBSD support
+There is also some initial effort on building and running Fin under OpenBSD, 
+so if you feel adventurous enough, you can give it a go. Since OpenBSD uses BSD Auth 
+instead of PAM, you will need to get the OpenPAM dependency first, by running:
+
+```shell
+$ doas pkg_add -U openpam
+```
+
+Afterwards, you can go to the Fin source folder and run `make embed` to test it out.
 
 
 # Screenshot

--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ instead of PAM, you will need to get the OpenPAM dependency first, by running:
 $ doas pkg_add -U openpam
 ```
 
+<<<<<<< HEAD
 Afterwards, you can go to the Fin source folder and run `make embed` to test it out.
+=======
+Next you need to set proper PAM rules:
+
+```
+$ doas install -Dm00644 /etc/pam.d/system /etc/pam.d/display_manager
+```
+
+Finally, you can go to the Fin source folder and run `make embed` to test it out.
+>>>>>>> c3db6c0 (More details about auth)
 
 
 # Screenshot

--- a/pam.c
+++ b/pam.c
@@ -1,7 +1,7 @@
 // The code in this file is from the excellent blog post https://www.gulshansingh.com/posts/how-to-write-a-display-manager/
 
 #include <security/pam_appl.h>
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <security/openpam.h>
 #else
 #include <security/pam_misc.h>

--- a/pam.go
+++ b/pam.go
@@ -3,7 +3,11 @@ package main
 /*
 #cgo LDFLAGS: -lpam
 #cgo openbsd CFLAGS: -I/usr/local/include
+<<<<<<< HEAD
 #cgo openbsd LDFLAGS: -L/usr/local//lib
+=======
+#cgo openbsd LDFLAGS: -L/usr/local/lib
+>>>>>>> fac6a73 (Addressing feedback)
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/pam.go
+++ b/pam.go
@@ -2,6 +2,8 @@ package main
 
 /*
 #cgo LDFLAGS: -lpam
+#cgo openbsd CFLAGS: -I/usr/local/include
+#cgo openbsd LDFLAGS: -L/usr/local//lib
 
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
Requires `pkg_add openpam`.

Display manager starts fine in embedded session with Xephyr.
To have the auth work, the following command needs to be run as root:
```
# install -Dm00644 /etc/pam.d/system /etc/pam.d/display_manager
```

At this time, the session crashes though (after successful login), needs further investigation to make this port viable.