### PR TITLE
Fix OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,11 @@ uninstall:
 embed:
 	DISPLAY=:0 Xephyr :1 -screen 1280x720 &
 	DISPLAY=:1 go run .
+	
+embed-obsd:
+	go build .
+	doas cp -f fin $(DESTDIR)$(PREFIX)/fin
+	doas chmod 4555 $(DESTDIR)$(PREFIX)/fin
+	Xephyr :1 -screen 1280x720 &
+	DISPLAY=:1 $(DESTDIR)$(PREFIX)/fin &
+	doas rm $(DESTDIR)$(PREFIX)/fin

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Next you need to set proper PAM rules:
 $ doas install -Dm00644 /etc/pam.d/system /etc/pam.d/display_manager
 ```
 
-Finally, you can go to the Fin source folder and run `make embed` to test it out.
+Finally, you can go to the Fin source folder and run `make embed-obsd` to test it out under Xephyr.
+
+Please, keep in mind that the actual running on bare X under OpenBSD is still work in progress, and 
+therefore you probably won't be able to login/authenticate for the time being.
 
 
 # Screenshot

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ func main() {
 }
 
 func startX() int {
-	cmd := "/usr/bin/X :0 vt01"
-	exe := exec.Command("/bin/bash", "-c", cmd)
+	cmd := "X :0 vt01"
+	exe := exec.Command("/bin/sh", "-c", cmd)
 	err := exe.Start()
 	if err != nil {
 		fyne.LogError("Could not start X server", err)

--- a/sessions.go
+++ b/sessions.go
@@ -12,7 +12,7 @@ import (
 
 var xinitSession = &session{
 	name: ".xinitrc",
-	exec: "/bin/bash --login .xinitrc",
+	exec: "/bin/sh -l .xinitrc",
 }
 
 type session struct {


### PR DESCRIPTION
- Makefile gets OpenBSD-specific embedding
- Remove bash reference to make Fin more portable and shell-agnostic