### PR TITLE
Make Fin work under OpenBSD boot

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,11 +19,3 @@ uninstall:
 embed:
 	DISPLAY=:0 Xephyr :1 -screen 1280x720 &
 	DISPLAY=:1 go run .
-	
-embed-obsd:
-	go build .
-	doas cp -f fin $(DESTDIR)$(PREFIX)/fin
-	doas chmod 4555 $(DESTDIR)$(PREFIX)/fin
-	Xephyr :1 -screen 1280x720 &
-	DISPLAY=:1 $(DESTDIR)$(PREFIX)/fin &
-	doas rm $(DESTDIR)$(PREFIX)/fin

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fin, the Fyne Login Manager
 
 A minimal but good-looking login manager for Linux/Unix.
-The current boot scripts support only systemd.
+The current boot scripts support only systemd on Linux and rc.d on OpenBSD.
 
 If you'd like to try out this project in its early stages
 then you can simply check out this repo and run (Linux with systemd assumed):
@@ -25,25 +25,23 @@ please visit [Troubleshooting](#troubleshooting) below.
 
 ### OpenBSD support
 
-There is also some initial effort on building and running Fin under OpenBSD, 
-so if you feel adventurous enough, you can give it a go. Since OpenBSD uses BSD Auth 
-instead of PAM, you will need to get the OpenPAM dependency first, by running:
+Fin builds and runs under OpenBSD as well. Since OpenBSD uses BSD Auth 
+instead of PAM, you will need to get the OpenPAM dependency first and set proper rules by running:
 
 ```shell
 $ doas pkg_add -U openpam
-```
-
-Next you need to set proper PAM rules:
-
-```
 $ doas install -Dm00644 /etc/pam.d/system /etc/pam.d/display_manager
 ```
 
-Finally, you can go to the Fin source folder and run `make embed-obsd` to test it out under Xephyr.
+To run Fin under bare X on system boot, install it with commands as following. If you have some other display manager enabled, make sure you disable it first, so it doesn't conflict with Fin. Below we assume that you have got `xenodm`, and disable it explicitly:
 
-Please, keep in mind that the actual running on bare X under OpenBSD is still work in progress, and 
-therefore you probably won't be able to login/authenticate for the time being.
+```shell
+$ doas make install
+$ doas rcctl disable xenodm
+$ doas rcctl enable fin
+```
 
+Reboot the system and Fin should start automatically during boot process.
 
 # Screenshot
 

--- a/fin.rc
+++ b/fin.rc
@@ -1,0 +1,22 @@
+#!/bin/ksh
+
+# OpenBSD rc script
+
+daemon="/usr/local/bin/fin"
+
+. /etc/rc.d/rc.subr
+
+rc_reload=NO
+
+rc_post() {
+	pkill -T "${daemon_rtable}" -f fin
+
+	if [[ -c /dev/dri/card0 ]]; then
+		chown root /dev/dri/card0
+	fi
+	if [[ -c /dev/dri/renderD128 ]]; then
+		chown root /dev/dri/renderD128
+	fi
+}
+
+rc_cmd $1

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 }
 
 func startX() int {
-	cmd := "X :0 vt01"
+	cmd := "X :0"
 	exe := exec.Command("/bin/sh", "-c", cmd)
 	err := exe.Start()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 }
 
 func startX() int {
-	cmd := "X :0"
+	cmd := "X :0 vt05"
 	exe := exec.Command("/bin/sh", "-c", cmd)
 	err := exe.Start()
 	if err != nil {

--- a/makefile
+++ b/makefile
@@ -1,0 +1,24 @@
+# OpenBSD makefile
+
+# If PREFIX isn't provided, we check for /usr/local and use that if it exists.
+# Otherwice we fall back to using /usr.
+
+LOCAL != test -d $(DESTDIR)/usr/local && echo -n "/local" || echo -n ""
+LOCAL ?= $(shell test -d $(DESTDIR)/usr/local && echo "/local" || echo "")
+PREFIX ?= /usr$(LOCAL)
+
+build:
+	go build . || (echo "Failed to build fin"; exit 1)
+
+install:
+	install -D -g bin fin $(DESTDIR)$(PREFIX)/bin/fin
+	install -Dm00555 fin.rc /etc/rc.d/fin
+
+uninstall:
+	rm $(DESTDIR)$(PREFIX)/bin/fin
+	rm /etc/rc.d/fin
+
+embed:
+	go build .
+	Xephyr :1 -screen 1280x720 &
+	DISPLAY=:1 doas ./fin


### PR DESCRIPTION
Finally, Fin works under OpenBSD during boot sequence as well - the initial port can be considered complete. A few bullet points though:

- Makefiles have been split into `GNUmakefile` and `makefile`. This allows to cater to both make tool setups - Linux uses GNU make and BSDs use classic make, but the user will simply run `make` and it will work automatically, no matter the system. Additionally, such approach solves the challenge with keeping system-unique target builds, while allowing to reuse same commands, like `make embed`
- explicit `vt01` argument from X initialization removed, as it was scrambling the keyboard input on OpenBSD, which assumes that X will guess what vt to use based on configs elsewhere. I haven't tested it on Linux, and although I suppose it should work the same, there might be caveats with how systemd and rootless X work there.  