### PR TITLE
Fix OpenBSD console and DRM

### DIFF
--- a/fin.rc
+++ b/fin.rc
@@ -3,13 +3,14 @@
 # OpenBSD rc script
 
 daemon="/usr/local/bin/fin"
+daemon_timeout=1
 
 . /etc/rc.d/rc.subr
 
-rc_reload=NO
-
 rc_post() {
-	pkill -T "${daemon_rtable}" -f fin
+	
+	chown root /dev/console
+	chmod 622 /dev/console
 
 	if [[ -c /dev/dri/card0 ]]; then
 		chown root /dev/dri/card0


### PR DESCRIPTION
Emulate GiveConsole/TakeConsole behavior, to manage device ownership on login/logout (and process stopping):

- https://github.com/openbsd/xenocara/blob/master/app/xenodm/config/GiveConsole.in
- https://github.com/openbsd/xenocara/blob/master/app/xenodm/config/TakeConsole.in