### PR TITLE
Set up proper ENV and PATH for OpenBSD and some minor text adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ $ doas pkg_add -U openpam
 $ doas install -Dm00644 /etc/pam.d/system /etc/pam.d/display_manager
 ```
 
-To run Fin under bare X on system boot, install it with commands as following. If you have some other display manager enabled, make sure you disable it first, so it doesn't conflict with Fin. Below we assume that you have got `xenodm`, and disable it explicitly:
+To run Fin under bare X on system boot, build and install it with commands as following. If you have some other display manager enabled, make sure you disable it first, so it doesn't conflict with Fin. Below we assume that you have got `xenodm`, and disable it explicitly:
 
 ```shell
+$ make build
 $ doas make install
 $ doas rcctl disable xenodm
 $ doas rcctl enable fin

--- a/pam.c
+++ b/pam.c
@@ -101,9 +101,27 @@ static void init_env(struct passwd *pw) {
     set_env("SHELL", pw->pw_shell);
     set_env("USER", pw->pw_name);
     set_env("LOGNAME", pw->pw_name);
-    set_env("PATH", "/usr/local/sbin:/usr/local/bin:/usr/bin");
     set_env("MAIL", _PATH_MAILDIR);
     set_env("DISPLAY", ":0");
+
+    #if defined(__OpenBSD__)
+    const char *path_def = "/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
+    size_t pathv_len = strlen(pw->pw_dir) + strlen(path_def) + 1;
+    char *pathv = malloc(pathv_len);
+    snprintf(pathv, pathv_len, "%s%s", pw->pw_dir, path_def);
+    set_env("PATH", pathv);
+    free(pathv);
+
+    const char *kshrc = "/.kshrc";
+    size_t env_len = strlen(pw->pw_dir) + strlen(kshrc) + 1;
+    char *envv = malloc(env_len);
+    snprintf(envv, env_len, "%s%s", pw->pw_dir, kshrc);
+    set_env("ENV", envv);
+    free(envv);
+
+    #else
+    set_env("PATH", "/usr/local/sbin:/usr/local/bin:/usr/bin");
+    #endif
 
     size_t xauthority_len = strlen(pw->pw_dir) + strlen("/.Xauthority") + 1;
     char *xauthority = malloc(xauthority_len);


### PR DESCRIPTION
Proper PATH init for OpenBSD mimics https://github.com/openbsd/src/blob/master/etc/skel/dot.profile

Additionally. ENV variable needs to be set in order to allow user-driven settings for ksh, as part of .kshrc file.
https://man.openbsd.org/ksh