### PR TITLE
Hide 'build' system user under OpenBSD

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -292,7 +292,7 @@ func getUsers() []string {
 
 	var ret []string
 	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "nologin") {
+		if strings.Contains(line, "nologin") || strings.Contains(line, "/var/empty") {
 			continue
 		}
 


### PR DESCRIPTION
OpenBSD has a special type of system user, named 'build', that requires login shell defined, and therefore is not filtered out by original logic for `nologin`. Additional check added for specific type of homedir, to cater to this case.