### PR TITLE
update staticcheck

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: WillAbides/setup-go-faster@v1.6.0
       with:
-        go-version: '1.17.x'     
+        go-version: '1.17.x'
 
     - name: Get dependencies
       run: |
@@ -34,4 +34,4 @@ jobs:
       run: golint -set_exit_status $(go list -tags ci ./...)
 
     - name: Staticcheck
-      run: staticcheck -go 1.14 ./...
+      run: staticcheck -go 1.17 ./...


### PR DESCRIPTION
previous version of staticcheck was referencing 1.14. now it's 1.17